### PR TITLE
Fix spelling in css link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
 	<title>{{ page.title }} | Melody Joy Kramer | Working and Thinking in Public.</title>
 	<!-- styles -->
 	<link href="/css/bootstrap.css" rel="stylesheet">
-	<link href="/css/jumbotron-narrow.css" rel="stylesheet">
+	<link href="/css/jumbotron.narrow.css" rel="stylesheet">
 	<link href="/css/style.css" rel="stylesheet">
 
 	<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->


### PR DESCRIPTION
This will fix the 404 around the stylesheet. Not sure if you really need it, since the site looks good without it.
If the site looks weird with this merged, then you can just delete line 12, so it isn't trying to load that stylesheet.