### PR TITLE
Remove link to missing javascript

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,4 @@
 <!-- javascript at the end of the doc so page loads faster -->
 <script src="http://code.jquery.com/jquery.js"></script>
 <script src="/js/bootstrap.min.js"></script>
-<script src="/js/library.js"></script>
 <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>


### PR DESCRIPTION
File isn't on the site, so getting a 404. Probably vestigial from the original theme.