### PR TITLE
Update viewport meta tag to use content

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" width="device-width, initial-scale=1.0">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="description" content="{{ page.description }}">
 	<meta name="author" content="Melody Kramer">
 	<!-- favicon


### PR DESCRIPTION
I think this is the proper syntax for this. Meta tags use name/content.
I'm not too great with this stuff, though, so it might not be the fix.

I'm basing it off our website (www.wearehearken.com) which our designer added the right tags for the responsiveness.